### PR TITLE
Add fennecdjay/Gwion

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,6 +86,9 @@
       <dt class="username"><a href="https://github.com/evincarofautumn">evincar</a></dt>
       <dd><a href="http://kittenlang.org">Kitten</a> is a statically typed concatenative language with effect types.</dd>
 
+      <dt class="username"><a href="https://github.com/fennecdjay">fennecdjay</a></dt>
+      <dd><a href="https://github.com/fennecdjay/Gwion">Gwion</a> is a strongly-timed musical programming language .</dd>
+
       <dt class="username">HackerFoo</dt>
         <dd><a href="https://github.com/HackerFoo/poprc">Popr</a>
            applies concatenative programming to types as well as values, striving for purity and correctness, and efficient execution.</dd>


### PR DESCRIPTION
Here it is.  
As I wrote on IRC, it tried to get this clean, so the html looks correct and they are no trainling spaces.

-----------
VIM complains on a few things at the and of the page.
One is about the`<tt>` flag, which is said to have been removed from html5, but I don't think this is a real issue.
But on the *egelbot* [entry](https://github.com/fennecdjay/proglangdesign.github.io/blob/master/index.html#L213), there are a few problems related to the `<dt>` flag. Shall I fix it?