### PR TITLE
Make the site more inclusive of the Discord and Subreddit communities

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,14 +1,14 @@
 <!doctype html>
 <html>
   <head>
-    <title>#proglangdesign</title>
+    <title>Programming Language Design</title>
     <meta charset="UTF-8">
     <link href="style.css" rel="stylesheet" type="text/css">
   </head>
 
   <body>
 
-    <h1>A website for the #proglangdesign community on freenode</h1>
+    <h1>A website for the Programming Language Design community</h1>
 
     <a href="https://github.com/proglangdesign/proglangdesign.github.io"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/a6677b08c955af8400f44c6298f40e7d19cc5b2d/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f677261795f3664366436642e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png"></a>
 
@@ -16,10 +16,10 @@
     <h2>People and Projects</h2>
 
     <p>
-    An incomplete list of nicknames on #proglangdesign and their labours
-    of love.  Some are definitely missing - just make a pull request
+    Here is an incomplete list of users by nickname and their labors
+    of love. Some are definitely missing — just make a pull request
     to <a href="https://github.com/proglangdesign/proglangdesign.github.io">the
-        Github repository</a> with the changes you want to see.
+        Github repository</a> with any changes you want to see.
     </p>
     <i>
       Entries are in alphabetically ascending order by username. Please keep them in order.
@@ -41,10 +41,10 @@
         <a href="http://web3d.jondgoodwin.com/acorn/index.html">Acorn</a>
         is a dynamic language with some of the same features.
       </dd>
-      
+
       <dt class="username">arBmind</dt>
       <dd>
-        The <a href="https://github.com/rebuild-lang">Rebuild Language Project</a> aims to 
+        The <a href="https://github.com/rebuild-lang">Rebuild Language Project</a> aims to
         research and hopefully build the ultimate system programming language.
         It's a collection of ideas and experiments to bring better concepts into programming languages.
         Watch an introduction talk on <a href="https://youtu.be/aKFjP8ozfjE">Youtube</a><br/>
@@ -77,7 +77,7 @@
       <dd><a href="https://github.com/cheery/lever">Lever</a>, a
       dynamically typed language built to absorb features from other
       languages.</dd>
-      
+
       <dt class="username">
         <a href="https://github.com/chrisosaurus">cjh`</a>
       </dt>
@@ -119,7 +119,7 @@
 
       <dt class="username">haldean</dt>
       <dd><a href="https://ubik.site">ubik</a> is a safe functional programming language for distributed and embedded programming on streams with an unorthodox syntax.</dd>
-        
+
       <dt class="username">htafdwes</dt>
       <dd><a href="http://pyac.ca">Pyash</a> is a language based on linguistic universals for totally taking over the world.</dd>
       <dt class="username">ilyash</dt>
@@ -133,7 +133,7 @@
 
       <dt class="username"><a href="https://github.com/joergen7">joergen7</a></dt>
       <dd>
-        <a href="https://cuneiform-lang.org">Cuneiform</a> is a large-scale data analysis functional programming language. It is open because it easily integrates foreign tools and libraries, e.g., Python libraries or command line tools. It is general because it has the expressive power of a functional programming language while automatically parallelizing and distributing program execution. Cuneiform uses distributed Erlang to scalably run in cluster and cloud environments. 
+        <a href="https://cuneiform-lang.org">Cuneiform</a> is a large-scale data analysis functional programming language. It is open because it easily integrates foreign tools and libraries, e.g., Python libraries or command line tools. It is general because it has the expressive power of a functional programming language while automatically parallelizing and distributing program execution. Cuneiform uses distributed Erlang to scalably run in cluster and cloud environments.
       </dd>
 
       <dt class="username">JX7P</dt>
@@ -155,7 +155,7 @@
 
       <dt class="username">Never</dt>
         <dd><a href="https://never-lang.github.io/never/">Never</a>
-          is a simple functional programming language. Technically it may be classified as syntactically scoped, strongly typed, call by value, functional programming language. In practise Never offers basic data types, assignment, control flow, arrays, first order functions, exceptions and some mathematical functions to make it useful to calculate expressions.    
+          is a simple functional programming language. Technically it may be classified as syntactically scoped, strongly typed, call by value, functional programming language. In practise Never offers basic data types, assignment, control flow, arrays, first order functions, exceptions and some mathematical functions to make it useful to calculate expressions.
         </dd>
 
       <dt class="username">Ori_B</dt>
@@ -185,12 +185,12 @@
           type system changes, etc.</dd>
 
       <dt class="username">SageCode</dt>
-      <dd><a href="https://github.com/sage-code/level-snippets/wiki">Level</a> 
-          Is a statically typed multi-paradigm language design for education 
-          in Computer Science. Syntax is inspired from Ada, Python and OCaml. 
+      <dd><a href="https://github.com/sage-code/level-snippets/wiki">Level</a>
+          Is a statically typed multi-paradigm language design for education
+          in Computer Science. Syntax is inspired from Ada, Python and OCaml.
           For compilers we use Rust, Julia, Golang, C++ and Python.
       </dd>
-          
+
       <dt class="username">
         <a href="https://github.com/slavfox">slavfox</a>
       </dt>
@@ -227,7 +227,7 @@
         <a href="https://github.com/xkapastel/denshi">Denshi</a> is
         an experimental programming environment.
       </dd>
-      
+
       <dt class="username">yorickpeterse</dt>
       <dd>
         <a href="https://github.com/YorickPeterse/inko">Inko</a> is a gradually
@@ -245,6 +245,13 @@
     </div>
 
     <div id="right-column">
+      <h2>Join Us!</h2>
+      <ul>
+        <li>on the <a href="https://webchat.freenode.net/?channels=proglangdesign">#proglangdesign IRC channel</a>.</li>
+        <li>on the <a href="https://discord.gg/hmch895">Programming Language Design Discord channel</a>.</li>
+        <li>on the <a href="https://www.reddit.com/r/ProgrammingLanguages/">/r/ProgrammingLanguages subreddit</a>.</li>
+      </ul>
+
       <h2>How do I join the IRC channel?</h2>
 
       <ul>
@@ -270,11 +277,6 @@
 
       <ul>
         <li>
-          <a href="https://www.reddit.com/r/ProgrammingLanguages/">The
-          /r/ProgrammingLanguages subreddit</a> is always a good source of
-          information, and many of the channel regulars are active there.
-        </li>
-        <li>
           <a href="http://profs.sci.univr.it/~merro/files/harper.pdf">Practical
           Foundations for Programming Languages (PDF)</a> is a very
           comprehensive introduction to programming language theory.
@@ -286,10 +288,6 @@
         </li>
       </ul>
 
-      <h2>Joining the GitHub organization</h2>
-
-      If you are a regular on #proglangdesign, ask hackerfoo for an invitation.
-
       <h2>Wiki</h2>
 
       <p>
@@ -299,6 +297,10 @@
       <p>
         Only members of the GitHub organization can edit the wiki.
       </p>
+
+      <h2>Joining the GitHub organization</h2>
+
+      <p>If you are a regular on #proglangdesign, ask hackerfoo for an invitation.</p>
 
       <h2>IRC bots</h2>
 


### PR DESCRIPTION
While the site apparently accepts additions of users and projects who aren't regulars on the IRC channel, it is still very focused on the IRC channel. Many users have been congregating on the discord chat and other users are on only the subreddit. This change makes the site more inclusive of those parts of the community.

Changes:

* Page title and header changed from "#proglangdesign" to "Programming Language Design"
* Update description under "People and Projects" to be inclusive
* Added "Join Us!" section to top right with links to IRC, discord, and subreddit. Thus making it clear that all three are part of the community.
* Removed the subreddit from handy links since it now appears in the join us section
* Moved "Wiki" section above "Joining the GitHub organization" because it seemed like the thing people would more frequently be interested in. Plus, it wasn't clear why you would want to join the GitHub organization until you knew it let you edit the wiki.

P.S. sorry for the removal of whitespace at the end of lines making the diff more confusing. My editor did that automatically on save.