### PR TITLE
Use my name rather than inconsistent aliases

### DIFF
--- a/index.xhtml
+++ b/index.xhtml
@@ -278,8 +278,8 @@
         <h3>Mercury</h3>
       </a>
       <span class="author">
-        <a href="https://www.reddit.com/u/PaulBone">PaulBone</a>
-        (among others)
+        <a href="http://mercurylang.org/development/people.html">Many</a>
+        including <a href="https://paul.bone.id.au">Paul Bone</a>.
       </span>
       <p>A logic/functional programming language
         with advanced static analysis and error detection features.</p>
@@ -350,9 +350,11 @@
         <img src="images/logo-plasma.png" alt="" />
         <h3>Plasma</h3>
       </a>
-      <span class="author"><a href="https://paul.bone.id.au/">Boney</a></span>
-      <p>A language to balance functional and imperative programming,
-        with state-of-the-art concurrency features.</p>
+      <span class="author">
+        <a href="https://paul.bone.id.au/">Paul Bone</a>
+      </span>
+      <p>A language that balances functional and imperative programming,
+        and has state-of-the-art concurrency and parallelism features.</p>
     </div>
     
     <div class="project">


### PR DESCRIPTION
I noticed I was "Boney" under one entry, and "PaulBone" under another.
I've changed this to "Paul Bone" and given my website's URL for both.  I
also tweaked the description of Plasma and deemphasised my work on
Mercury (it previously looked like I was a founder, I was not).