### PR TITLE
Add canonical URL for main page

### DIFF
--- a/index.xhtml
+++ b/index.xhtml
@@ -17,6 +17,8 @@
   <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5" />
   <meta name="msapplication-TileColor" content="#da532c" />
   <meta name="theme-color" content="#ffffff" />
+
+  <link rel="canonical" href="https://www.proglangdesign.net/" />
 </head>
 <body>
   <header>


### PR DESCRIPTION
I don't expect this will be at all controversial. It establishes that `https://www.proglangdesign.net/` is the canonical URL, not `https://www.proglangdesign.net/index.xhtml`.