### PR TITLE
Adding in Horse64 with logo URL-referenced (since it's not MIT-licensed)

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -89,6 +89,15 @@ Futhark:
   author: Athas
   summary: A high-performance parallel functional array language targeting GPUs.
 
+Horse64:
+  website: https://horse64.org/
+  github.com: horse64/horse64
+  author: ell1e
+  icon: https://horse64.org/horse64logo.png
+  summary: >
+    Dynamically typed but more orderly, reducing pain and chaos in
+    large code bases. Like Python, but saner.
+
 Inko:
   website: https://inko-lang.org/
   gitlab: inko-lang/inko

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -95,8 +95,8 @@ Horse64:
   author: ell1e
   icon: https://horse64.org/horse64logo.png
   summary: >
-    Dynamically typed but more orderly, reducing pain and chaos in
-    large code bases. Like Python, but saner.
+    Dynamically typed but orderly, reducing chaos in
+    large projects. Like Python, but saner.
 
 Inko:
   website: https://inko-lang.org/


### PR DESCRIPTION
This pull request would add in the Horse64 language I am working on. Please note I referenced the logo via URL rather than adding it in on purpose, since it's licensing doesn't match the MIT license in this repository, and I also find it advantageous that it'll automatically stay up-to-date.