### PR TITLE
Update Horse64 entry to use small-space compatible one

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -93,7 +93,7 @@ Horse64:
   website: https://horse64.org/
   github.com: horse64/horse64
   author: ell1e
-  icon: https://horse64.org/horse64logo.png
+  icon: https://horse64.org/horse64logosmall.png
   summary: >
     Dynamically typed but orderly, reducing chaos in
     large projects. Like Python, but saner.


### PR DESCRIPTION
I accidentally added in the logo variant that looks really poorly scaled down :eyes: :scream: even though I have one that works nicely in smaller spaces. So I apologize for yet another pull request, but this one changes the Horse64 logo URL accordingly such that it looks nicer in the  `proglangdesign.net` listing