### PR TITLE
Update Horse64 text to be less potentially negative on Python

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -96,7 +96,7 @@ Horse64:
   icon: https://horse64.org/horse64logosmall.png
   summary: >
     Dynamically typed but orderly, reducing chaos in
-    large projects. Like Python, but saner.
+    large projects. A grounded Python-alike.
 
 Inko:
   website: https://inko-lang.org/


### PR DESCRIPTION
Updating Horse64's text since my previous summary could have been read as a slight stab on Python, which doesn't feel like a useful thing to do in retrospect. I think this new text makes it more obvious it's a different spin on a Python-alike while hopefully no longer possibly suggesting Python as somehow comparatively worse.