### PR TITLE
Add gwionbot reference

### DIFF
--- a/index.xhtml
+++ b/index.xhtml
@@ -153,6 +153,10 @@ canonical: /
       <span class="shell">sturluson:</span> 
       Speaks <a href="https://futhark-lang.org/">Futhark</a>.
     </li>
+    <li>
+      <span class="shell">gwionbot:</span> 
+      Speaks <a href="https://Gwion.github.io/Gwion/">Gwion</a>.
+    </li>
   </ul>
   <p>
     To try out a bot, simply say


### PR DESCRIPTION
Since bots speaking languages off the project are welcome (see #103), gwionbot is now live on proglangdesign.
This PR adds a reference to this bot, in the dedicated place.

---
I don't know if the issue has to be closed, so I let it open now, other languages devs might find the info interresting.