### PR TITLE
Fix Calypso's icon

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -28,7 +28,7 @@ Bee:
 Calypso:
   website: https://thepuzzlemaker.github.io/Calypso/
   github: ThePuzzlemaker/Calypso
-  image: calypso.png
+  icon: calypso.png
   organization:
     name: Calypso Contributors
     website: https://github.com/ThePuzzlemaker/Calypso/blob/master/LICENSE


### PR DESCRIPTION
I accidentally put `image` instead of `icon`