### PR TITLE
Add tags for Plasma and Mercury

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -410,6 +410,13 @@ Plasma:
   summary: >
     A language that balances functional and imperative programming,
     and has state-of-the-art concurrency and parallelism features.
+  tags:
+    - compiled
+    - parallel
+    - concurrent
+    - strong types
+    - static types
+    - pure
 
 Pikelet:
   website: https://pikelet-lang.github.io/pikelet/

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -304,6 +304,12 @@ Mercury:
   summary: >
     A logic/functional programming language
     with advanced static analysis and error detection features.
+  tags:
+    - logic
+    - compiled
+    - strong types
+    - static types
+    - pure
 
 Mlatu:
   website: https://brightly-salty.github.io/mlatu/

--- a/_data/tags.yml
+++ b/_data/tags.yml
@@ -7,3 +7,8 @@
 - gpu
 - reactive
 - scripting
+- parallel
+- concurrent
+- strong types
+- static types
+- pure

--- a/_data/tags.yml
+++ b/_data/tags.yml
@@ -1,6 +1,7 @@
 - oop
 - functional
 - imperative
+- logic
 - compiled
 - systems
 - jvm


### PR DESCRIPTION
These patches add tags for the Plasma and Mercury languages.

BTW.  should Mercury have the JVM tag.  JVM is one of it's mulitple backends but it's not a JVM language the way Clojure is, the integration isn't that strong.

I've made the branch from the point on master where these tags existed, I figured that'd be easiest to eventually re-enable the feature from.