### PR TITLE
Fix link to Firefly github

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -142,7 +142,7 @@ Fennel:
 
 Firefly:
   website: https://www.ahnfelt.net/async-await-inference-in-firefly/
-  github: https://github.com/Ahnfelt/firefly-boot
+  github: Ahnfelt/firefly-boot
   icon: firefly.png
   discord: y8zCf7x2pF
   authors:


### PR DESCRIPTION
Update Github link for `Firefly` language.

Link at [projects.yml](https://github.com/proglangdesign/proglangdesign.github.io/blob/master/_data/projects.yml#L145) was broken. It redirected to `https://github.com/https://github.com/Ahnfelt/firefly-boot` instead of `https://github.com/Ahnfelt/firefly-boot`. I fixed it