### PR TITLE
Fixed typo and removed link to Github repository

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -291,15 +291,13 @@ Peridot:
     A fast functional language based on two level type theory
 
 Lapla:
-  github: devtaube/lapla # private at the moment, but this will be the public repo later
   discord: vpK7gCc5ST
   author:
     name: Quentin Börger
     website: https://devtaube.netlify.app/
   summary: >
     Lapla is a compiled programming language. The compiler is built with the goal
-    of stopping all critcal runtime errors at compile time,
-    from out of bounds indices to illegal states.
+    of stopping all critical runtime errors at compile time.
 
 Lesma:
   website: https://lesma-lang.com/


### PR DESCRIPTION
Fixed a typo in the summary of Lapla and removed the link to it's Github repository