### PR TITLE
Update the link for `Chaos`

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -72,6 +72,7 @@ C3:
     semantic macros.
 
 Chaos:
+  website: https://web.archive.org/web/20220826230202/https://chaos-lang.org/
   github: chaos-lang/chaos
   libera: chaoslang
   gitter: chaos-lang/community

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -72,7 +72,6 @@ C3:
     semantic macros.
 
 Chaos:
-  website: https://chaos-lang.org/
   github: chaos-lang/chaos
   libera: chaoslang
   gitter: chaos-lang/community


### PR DESCRIPTION
The link for the `Chaos`-language (https://chaos-lang.org/) currently links to a casino site? This probably wasn't always the case, but it seems to be now. A member of the discord server noticed this, so I hereby suggest removing the link.