### PR TITLE
Change Gera website link

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -233,7 +233,7 @@ Futhark:
   summary: A high-performance parallel functional array language targeting GPUs.
 
 Gera:
-  website: https://github.com/geralang/
+  website: https://geralang.netlify.app/
   author: TypeSafeSchwalbe
   icon: gera.svg
   discord: DYRDg7fq82


### PR DESCRIPTION
Change the Gera website link from the Github organization to the actual Gera website