### PR TITLE
Add dynamic types to tags.yml

### DIFF
--- a/_data/tags.yml
+++ b/_data/tags.yml
@@ -1,6 +1,7 @@
 # please keep in alphabetical order
 - compiled
 - concurrent
+- dynamic types
 - educational
 - esoteric
 - functional


### PR DESCRIPTION
In https://github.com/proglangdesign/proglangdesign.github.io/pull/219 I put "dynamic types" for some languages since it's the natural opposite to "static types" and mentioned in the descriptions, but I forgot to add it to the tags list. Sorry about that.

Alternatively, I could also remove the "dynamic types" entries again if that is preferred.