### PR TITLE
Fix syntax error in projects.yml

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -859,7 +859,7 @@ Sophie:
   summary: >
     🦆 Call-by-need statically-duck-typed pure-functional language with actor-based concurrency,
     named for French mathematician Sophie Germain.
-  tags;
+  tags:
     - concurrent
     - pure
     - functional


### PR DESCRIPTION
In https://github.com/proglangdesign/proglangdesign.github.io/pull/219 I introduced a syntax error without noticing. This change fixes the syntax error.