### PR TITLE
Add details to Horse64 and Horse64 Root, including new "garbage collection" tag

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -350,6 +350,11 @@ Horse64:
     large projects. A grounded Python-alike.
   tags:
     - dynamic types
+    - concurrent
+    - garbage collection
+    - imperative
+    - object-oriented
+    - strong types
 
 Horse64 Root:
   website: https://root.horse64.org/
@@ -358,10 +363,13 @@ Horse64 Root:
   git: https://codeberg.org/Horse64/root.horse64.org
   summary: >
     A system language similar to C/C++, reimagined with a focus on
-    approachable syntax, understandable OOP, and some baked-in
+    easy syntax, understandable OOP, and some baked-in
     safety features.
   tags:
+    - imperative
+    - object-oriented
     - static types
+    - strong types
     - systems
 
 ilo Token:

--- a/_data/tags.yml
+++ b/_data/tags.yml
@@ -5,6 +5,7 @@
 - esoteric
 - functional
 - first-class types
+- garbage collection
 - logic
 - parallel
 - pure


### PR DESCRIPTION
This adds some more details to the Horse64 and Horse64 Root list entries, including the new "garbage collection" tag which I imagine will be useful for many other langs to use as well.