### PR TITLE
Add higher z-index to repo icons to make sure they remain usable

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -55,7 +55,7 @@ section { max-width: 960px; margin: 0 auto; }
 .project h3 { display: inline-block; font-size: 1.5em; }
 .project a:hover { text-decoration: none; }
 .project > a > h3:hover { text-decoration: underline; }
-.repo-icons { float: right; }
+.repo-icons { float: right; z-index: 99; }
 .repo-icons img:not(.nofilter) {
   filter: invert(40%);
 }


### PR DESCRIPTION
This change adds a higher z-index to repo icons. This is meant to address when a lang entry has a too long title or too long creator's name, which often leads to the icons getting pushed to a separate line and to (invisibly) overlap with the other text spans:

<img width="355" height="182" alt="Screenshot_20250921_133645" src="https://github.com/user-attachments/assets/ae5aee21-7d9d-4aa8-939e-5b413196685a" />


The overlap can currently cause the icons to be unclickable. The higher z-index fixes t his.