### PR TITLE
An attempt to be able to move inactive projects into a separate section (feedback wanted if this is a good idea!)

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -3,6 +3,7 @@ Aardvark:
   discord: pjzDByMTx9
   github: Aardvark-team/Aardvark
   author: The Aardvark Team
+  inactive: yes
   icon: aardvark.svg
   summary: >
     It is designed to be easy, yet powerful, compiling to LLVM and self-hosting. Our goal is for it to be faster than C and easier than Python.
@@ -25,11 +26,13 @@ Alox:
   github: alox-lang/alox
   author: phase
   summary: GPU-Accelerated, Distributed, Actor Model Language
+  inactive: yes
 
 Amp:
   github: amp-lang/amp
   author: Zack Pace
   icon: amp.svg
+  inactive: yes
   summary: >
     A minimalistic systems language for modern software
   tags:
@@ -40,6 +43,7 @@ Amun:
   github: amrdeveloper/amun
   author: Amr Hesham
   icon: amun.svg
+  inactive: yes
   summary: >
     A low-level programming language with a simple and productive design inspired by C/C++, Rust, Go, Jai.
 
@@ -95,6 +99,7 @@ Calypso:
   author:
     name: James (ThePuzzlemaker)
     website: https://thepuzzlemaker.info
+  inactive: yes
   summary: >
     Calypso is a mostly imperative language with some functional influences that is focused on flexibility and simplicity.
   tags:
@@ -136,6 +141,7 @@ Chaos:
   libera: chaoslang
   gitter: chaos-lang/community
   icon: chaos.png
+  inactive: yes
   author:
     name: mertyildiran
     website: https://mertyildiran.com/

--- a/css/style.css
+++ b/css/style.css
@@ -48,7 +48,7 @@ header nav a { margin-left: 20px; }
 section { max-width: 960px; margin: 0 auto; }
 
 #projects { display: flex; flex-wrap: wrap; padding-bottom: 25px; }
-#projects-list { display: flex; flex-wrap: wrap; padding-bottom: 25px; }
+.projects-list { display: flex; flex-wrap: wrap; padding-bottom: 25px; }
 #projects h2 { width: 100%;  color: #444;}
 #projects project-title { font-size:1.5em; font-weight: bold;
     display:inline-block;}

--- a/index.html
+++ b/index.html
@@ -35,10 +35,13 @@ canonical: /
   <!-- Liquid, the templating language, is incredibly underpowered. -->
   <!-- What follows is very ugly code that is not possible to improve due to lack of features. -->
 
-  <div id="projects-list">
+  <div class="projects-list">
     {% for project_entry in site.data.projects %}
     {% assign project = project_entry[1] %}
     {% assign project_name = project_entry[0] %}
+    {% if project.inactive %}
+
+    {% else %}
     <div class="project" id="project-{{ project_name | downcase | replace: " ", "-" | escape }}"  data-tags="{{ project.tags | join: ',' }}">
       <span class="title">
         {% if project.website %}<a href="{{ project.website }}">{% endif %}
@@ -113,8 +116,45 @@ canonical: /
       </span>
       <p>{{ project.summary }}</p>
     </div>
+    {% endif %}
     {% endfor %}
   </div>
+  <h3>Inactive projects:</h3>
+  <p>The following projects have had no commits for two years or longer,
+  or their main website is defunct with no commits in the last months:</p>
+  <div class="projects-list">
+    {% for project_entry in site.data.projects %}
+    {% assign project = project_entry[1] %}
+    {% assign project_name = project_entry[0] %}
+    {% if project.inactive %}
+    <div class="project" id="project-{{ project_name | downcase | replace: " ", "-" | escape }}"  data-tags="{{ project.tags | join: ',' }}">
+      <span class="title">
+        {% if project.website %}<a href="{{ project.website }}">{% endif %}
+          {% if project.icon and project.icon contains "://" %}
+          <img src="{{ project.icon }}" alt="">
+          {% else %}
+          <img src="/images/lang/{{ project.icon | default: 'placeholder.png' }}" alt="">
+          {% endif %}
+          <h3>{{ project_name }}</h3>
+        {% if project.website %}</a>{% endif %}
+      </span>
+      <span class="repo-icons">
+        {% if project.github %}<a href="https://github.com/{{ project.github }}">
+          <img alt="GitHub" src="/images/github.svg">
+        </a>{% endif %}
+        {% if project.gitlab %}<a href="https://gitlab.com/{{ project.gitlab }}">
+          <img alt="GitLab" src="/images/gitlab.svg">
+        </a>{% endif %}
+        {% if project.git %}<a href="{{ project.git }}">
+          <img alt="Git" src="/images/git.svg">
+        </a>{% endif %}
+      </span>
+      <p>{{ project.summary }}</p>
+    </div>
+    {% endif %}
+    {% endfor %}
+  </div>
+
 </section>
 
 <section id="irc">

--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@ canonical: /
     {% for project_entry in site.data.projects %}
     {% assign project = project_entry[1] %}
     {% assign project_name = project_entry[0] %}
-    {% if project.inactive %}
+    {% if project.inactive and project.inactive contains "yes" %}
 
     {% else %}
     <div class="project" id="project-{{ project_name | downcase | replace: " ", "-" | escape }}"  data-tags="{{ project.tags | join: ',' }}">
@@ -126,7 +126,7 @@ canonical: /
     {% for project_entry in site.data.projects %}
     {% assign project = project_entry[1] %}
     {% assign project_name = project_entry[0] %}
-    {% if project.inactive %}
+    {% if project.inactive and project.inactive contains "yes" %}
     <div class="project" id="project-{{ project_name | downcase | replace: " ", "-" | escape }}"  data-tags="{{ project.tags | join: ',' }}">
       <span class="title">
         {% if project.website %}<a href="{{ project.website }}">{% endif %}

--- a/static/filter.js
+++ b/static/filter.js
@@ -1,7 +1,7 @@
 // Filters the projects by tags defined in projects.yml
 // Implemented by Matt Hall (github.com/mh15)
 
-const projects = document.querySelector("#projects-list")
+const projects = document.querySelector(".projects-list")
 const filters = new Set()
 
 // Only enable the feature if JS is enabled


### PR DESCRIPTION
I made an attempt to be able to mark projects as inactive via `inactive: yes`.

This commit includes a short description of what I think makes most sense as inactive (which is no commits for more than two years, or website dead with no commits in recent months), and I reworked the website template to hopefully show these inactive projects separately so that active projects get shown more prominently. The inactive list is way less detailed so that it remains easier to maintain, since it needs a separate section in the template handling. A project can be easily moved back to active by simply removing the `inactive: yes` data entry again.

I don't really know if this will work without major bugs on the live website. But I guess the best test would be to simply merge it and try it out, or is there any other way to test this in advance?