### PR TITLE
Try to fix markup issues caused by space characters in language names

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@ canonical: /
     {% for project_entry in site.data.projects %}
     {% assign project = project_entry[1] %}
     {% assign project_name = project_entry[0] %}
-    <div class="project" id="project-{{ project_name | downcase }}"  data-tags="{{ project.tags | join: ',' }}">
+    <div class="project" id="project-{{ project_name | downcase | replace: " ", "-" | escape }}"  data-tags="{{ project.tags | join: ',' }}">
       <span class="title">
         {% if project.website %}<a href="{{ project.website }}">{% endif %}
           {% if project.icon and project.icon contains "://" %}


### PR DESCRIPTION
I noticed that language names with a space character break the markup by leading to a broken element id. This change attempts to mitigate the problem.