### PR TITLE
Fix tag sort to be case insensitive like the project source data also is

### DIFF
--- a/static/filter.js
+++ b/static/filter.js
@@ -59,7 +59,7 @@ function projectComparator(a, b) {
         return 1
     } else {
         // Sort unfiltered items alphabetically
-        return a.innerText > b.innerText ? 1 : -1
+        return a.innerText.toLowerCase() > b.innerText.toLowerCase() ? 1 : -1
     }
 }
 


### PR DESCRIPTION
The `_data/projects.yml` file is, as far as it is still sorted at all, sorted in a case insensitive way. Currently, the JavaScript for the tags will sort the projects in some case sensitive way. This leads to inconsistencies. Therefore, this change should fix the JS to sort in a case insensitive manner as well.