### PR TITLE
Fix small tag info heading to be less annoying

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -112,6 +112,10 @@ section > h2, section > h3 { padding-top: 15px; padding-bottom: 5px; }
     background-color: rgb(100 70 103 / 38%);
 }
 
+.tags-summary-field h4 {
+  opacity:50%;
+}
+
 .tags-summary-field tag-desc {
     display:block;
     font-style:italic;
@@ -175,6 +179,9 @@ span.author:before { font-style: normal; content: "by "; }
 
 /* Dark mode tweaks: */
 @media (prefers-color-scheme: dark) {
+   .tags-summary-field h4 {
+     opacity:50%;
+   }
    #pagelink, a {
      color:#E0A0F0;
    }


### PR DESCRIPTION
The title of the sub section was a little distracting, so I toned down the intensity. This uses opacity instead of overriding the color, so that the text color of custom themes will be preserved.