### PR TITLE
Add a tag description proposal for the scripting tag

### DIFF
--- a/_data/tags.yml
+++ b/_data/tags.yml
@@ -36,7 +36,9 @@ parallel:
 pure:
   description: null
 scripting:
-  description: null
+  description: >
+    The makers of the language intend it to be used for scripting
+    tasks, like short one-shot program and automations.
 static types:
   description: null
 strong types:


### PR DESCRIPTION
I've often seen discussions what is a scripting language and what isn't, and probably most languages can be "misused" for scripting tasks even if not intended for that. So I figured perhaps it makes most sense if it's decided by the people making the language if that is it's purpose? And that it might make sense to put that as a tag description, as guidance for people adding their languages to the list in the future.

Any other suggestions or protest welcome.